### PR TITLE
release: 22 Nov 2023

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
         with:
           name: build
           path: build
-      - name: Create a release
+      - name: Create a prerelease
         run: npx semantic-release
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy to Staging

--- a/bin/test.js
+++ b/bin/test.js
@@ -40,6 +40,7 @@ function cleanBody(body) {
 }
 
 function parseMessage(commit) {
+  console.log(commit);
   const lines = commit
     .split(/\n{2}/)
     .map((p) => p.trim())

--- a/bin/test.js
+++ b/bin/test.js
@@ -98,6 +98,8 @@ async function main() {
       acc[commit.type] = (acc[commit.type] ?? []).concat(commit);
       return acc;
     }, {});
+  
+  console.log(commits);
 
   const featuresList = [...(commits.feature ?? []), ...(commits.feat ?? [])].map((commit) => formatCommit(commit));
   const updatesList = commits.update?.map((commit) => formatCommit(commit));

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,6 +1,94 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
 const execSync = require('child_process').execSync;
 
-const commits = execSync(`git log master..HEAD --pretty='format:%s%n%n%b${delimiter}'`)
+const SUBJECT_REGEX = /(\w+?)(!)?:.*/i;
+
+const createItem = (title, body) => {
+  return title &&
+    body?.length &&
+`## ${title}
+
+${body.join('\n')}
+`;
+};
+
+function formatCommit(commit) {
+  const taskFooter = commit.footers.find((footer) => footer.startsWith('Task:'));
+  let taskId;
+
+  if (taskFooter) {
+    taskId = taskFooter.split(':')[1]?.trim();
+  }
+  return commit.changes
+    .map((change) => `* ${change}${taskId ? ` - [Task-${taskId}](https://app.productive.io/109-productive/tasks/task/${taskId})` : ''}`)
+    .join('\n');
+}
+
+function cleanBody(body) {
+  return body
+    .reduce((acc, bodyItem) => {
+      return acc.concat(bodyItem.split('\n'));
+    }, [])
+    .map((bodyItem) => {
+      return bodyItem
+        .replace('*', '')
+        .trim();
+    })
+    .filter(Boolean);
+}
+
+function parseMessage(commit) {
+  const lines = commit
+    .split(/\n{2}/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+
+  if (!lines.length) {
+    return null;
+  }
+
+  const subject = lines[0];
+  const body = lines.length > 2 ?
+    lines.slice(1, lines.length - 1) :
+    lines.slice(1);
+  const footers = lines.length > 2 ?
+    lines[lines.length - 1]
+      .split('\n')
+      .filter(Boolean) :
+    [];
+
+  const subjectMatch = subject.trim().match(SUBJECT_REGEX);
+  const type = subjectMatch?.[1];
+
+  if (!type || !body.length) {
+    return null;
+  }
+
+  const isBreaking = Boolean(subjectMatch?.[2]);
+
+  const changes = cleanBody(body)
+    .map((change) => {
+      return `${isBreaking ? '⚠️ ' : ''}${change}`;
+    })
+    .filter((change) => !(/Task:\s\d+/i).test(change));
+    // Remove formatted data from body - invalid message
+
+  if (changes.length === 0) {
+    return null;
+  }
+
+  return {
+    type,
+    changes,
+    footers
+  };
+}
+
+async function main() {
+  const delimiter = '-----';
+  const commits = execSync(`git log master..HEAD --pretty='format:%s%n%n%b${delimiter}'`)
     .toString()
     .replaceAll('\r\n', '\n')
     .split(delimiter)
@@ -11,4 +99,23 @@ const commits = execSync(`git log master..HEAD --pretty='format:%s%n%n%b${delimi
       return acc;
     }, {});
 
-console.log(commits + ' heheooo');
+  const featuresList = [...(commits.feature ?? []), ...(commits.feat ?? [])].map((commit) => formatCommit(commit));
+  const updatesList = commits.update?.map((commit) => formatCommit(commit));
+  const betaFlagsList = commits.beta?.map((commit) => formatCommit(commit));
+  const bugsList = commits.fix?.map((commit) => formatCommit(commit));
+
+  const rendered = [
+    createItem('🧭 New Features', featuresList),
+    createItem('⭐️ Updates', updatesList),
+    createItem('🧪 Beta features', betaFlagsList),
+    createItem('🐞 Bugs Fixed', bugsList)
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  execSync(`echo "${rendered}" | pbcopy`);
+  console.log(rendered);
+  console.log('Release note copied to clipboard');
+}
+
+main();

--- a/bin/test.js
+++ b/bin/test.js
@@ -88,7 +88,7 @@ function parseMessage(commit) {
 
 async function main() {
   const delimiter = '-----';
-  const commits = execSync(`git log master..HEAD --pretty='format:%s%n%n%b${delimiter}'`)
+  const commits = execSync(`git log main..HEAD --pretty='format:%s%n%n%b${delimiter}'`)
     .toString()
     .replaceAll('\r\n', '\n')
     .split(delimiter)

--- a/bin/test.js
+++ b/bin/test.js
@@ -113,8 +113,8 @@ async function main() {
     .filter(Boolean)
     .join('\n');
 
+  console.log('pls')
   console.log(rendered);
-  console.log('Release note copied to clipboard');
 }
 
 main();

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,3 +1,5 @@
+const execSync = require('child_process').execSync;
+
 const commits = execSync(`git log master..HEAD --pretty='format:%s%n%n%b${delimiter}'`)
     .toString()
     .replaceAll('\r\n', '\n')

--- a/bin/test.js
+++ b/bin/test.js
@@ -113,7 +113,6 @@ async function main() {
     .filter(Boolean)
     .join('\n');
 
-  execSync(`echo "${rendered}" | pbcopy`);
   console.log(rendered);
   console.log('Release note copied to clipboard');
 }

--- a/bin/test.js
+++ b/bin/test.js
@@ -88,7 +88,7 @@ function parseMessage(commit) {
 
 async function main() {
   const delimiter = '-----';
-  const commits = execSync(`git log main..HEAD --pretty='format:%s%n%n%b${delimiter}'`)
+  const commits = execSync(`git log origin/main..HEAD --pretty='format:%s%n%n%b${delimiter}'`)
     .toString()
     .replaceAll('\r\n', '\n')
     .split(delimiter)

--- a/bin/test.js
+++ b/bin/test.js
@@ -22,7 +22,7 @@ console.log(`
 * Allow saving subscription form if it's not dirty - [Task-4884578](https://app.productive.io/109-productive/tasks/task/4884578)
 * Fixed sorting by due date and assignee on tasks screen - [Task-4941997](https://app.productive.io/109-productive/tasks/task/4941997)
 * Client roles are removed from budget membership picker - [Task-4877159](https://app.productive.io/109-productive/tasks/task/4877159)
-* Removed the label Overhead - Turned off/on if overhead is disabled in settings - [Task-4936699](https://app.productive.io/109-productive/tasks/task/4936699)
+* Removed the label "Overhead - Turned off/on" if overhead is disabled in settings - [Task-4936699](https://app.productive.io/109-productive/tasks/task/4936699)
 * Fixed the option to hide and show fields on the task modal - [Task-4913101](https://app.productive.io/109-productive/tasks/task/4913101)
 * Default date format selected in settings is now being used inside all tables, lists, boards, calendars and timelines
 `)

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,0 +1,12 @@
+const commits = execSync(`git log master..HEAD --pretty='format:%s%n%n%b${delimiter}'`)
+    .toString()
+    .replaceAll('\r\n', '\n')
+    .split(delimiter)
+    .map(parseMessage)
+    .filter(Boolean)
+    .reduce((acc, commit) => {
+      acc[commit.type] = (acc[commit.type] ?? []).concat(commit);
+      return acc;
+    }, {});
+
+console.log(commits + ' heheooo');

--- a/bin/test.js
+++ b/bin/test.js
@@ -113,7 +113,6 @@ async function main() {
     .filter(Boolean)
     .join('\n');
 
-  console.log('pls')
   console.log(rendered);
 }
 

--- a/bin/test.js
+++ b/bin/test.js
@@ -1,122 +1,28 @@
-/* eslint-env node */
-/* eslint-disable no-console */
+console.log(`
+## 🧭 New Features
 
-const execSync = require('child_process').execSync;
+* Implemented collapse of boards and lists on gantt layout - [Task-4653671](https://app.productive.io/109-productive/tasks/task/4653671)
+* Users can now create, edit and delete trigger for their automation through new automation builder component. - [Task-4813940](https://app.productive.io/109-productive/tasks/task/4813940)
 
-const SUBJECT_REGEX = /(\w+?)(!)?:.*/i;
+## ⭐️ Updates
 
-const createItem = (title, body) => {
-  return title &&
-    body?.length &&
-`## ${title}
+* Allow decimal points on invoice tax line item - [Task-4911517](https://app.productive.io/109-productive/tasks/task/4911517)
 
-${body.join('\n')}
-`;
-};
+## 🧪 Beta features
 
-function formatCommit(commit) {
-  const taskFooter = commit.footers.find((footer) => footer.startsWith('Task:'));
-  let taskId;
+* Introduced a new beta flag for skipping hourly rate conversion on frontend for hourly rate, opts-in the same conversion on backend
+* Show that purchase orders will be deleted when deleting a budget
 
-  if (taskFooter) {
-    taskId = taskFooter.split(':')[1]?.trim();
-  }
-  return commit.changes
-    .map((change) => `* ${change}${taskId ? ` - [Task-${taskId}](https://app.productive.io/109-productive/tasks/task/${taskId})` : ''}`)
-    .join('\n');
-}
+## 🐞 Bugs Fixed
 
-function cleanBody(body) {
-  return body
-    .reduce((acc, bodyItem) => {
-      return acc.concat(bodyItem.split('\n'));
-    }, [])
-    .map((bodyItem) => {
-      return bodyItem
-        .replace('*', '')
-        .trim();
-    })
-    .filter(Boolean);
-}
-
-function parseMessage(commit) {
-  console.log(commit);
-  const lines = commit
-    .split(/\n{2}/)
-    .map((p) => p.trim())
-    .filter(Boolean);
-
-  if (!lines.length) {
-    return null;
-  }
-
-  const subject = lines[0];
-  const body = lines.length > 2 ?
-    lines.slice(1, lines.length - 1) :
-    lines.slice(1);
-  const footers = lines.length > 2 ?
-    lines[lines.length - 1]
-      .split('\n')
-      .filter(Boolean) :
-    [];
-
-  const subjectMatch = subject.trim().match(SUBJECT_REGEX);
-  const type = subjectMatch?.[1];
-
-  if (!type || !body.length) {
-    return null;
-  }
-
-  const isBreaking = Boolean(subjectMatch?.[2]);
-
-  const changes = cleanBody(body)
-    .map((change) => {
-      return `${isBreaking ? '⚠️ ' : ''}${change}`;
-    })
-    .filter((change) => !(/Task:\s\d+/i).test(change));
-    // Remove formatted data from body - invalid message
-
-  if (changes.length === 0) {
-    return null;
-  }
-
-  return {
-    type,
-    changes,
-    footers
-  };
-}
-
-async function main() {
-  const delimiter = '-----';
-  const commits = execSync(`git log origin/main..HEAD --pretty='format:%s%n%n%b${delimiter}'`)
-    .toString()
-    .replaceAll('\r\n', '\n')
-    .split(delimiter)
-    .map(parseMessage)
-    .filter(Boolean)
-    .reduce((acc, commit) => {
-      acc[commit.type] = (acc[commit.type] ?? []).concat(commit);
-      return acc;
-    }, {});
-  
-  console.log(commits);
-
-  const featuresList = [...(commits.feature ?? []), ...(commits.feat ?? [])].map((commit) => formatCommit(commit));
-  const updatesList = commits.update?.map((commit) => formatCommit(commit));
-  const betaFlagsList = commits.beta?.map((commit) => formatCommit(commit));
-  const bugsList = commits.fix?.map((commit) => formatCommit(commit));
-
-  const rendered = [
-    createItem('🧭 New Features', featuresList),
-    createItem('⭐️ Updates', updatesList),
-    createItem('🧪 Beta features', betaFlagsList),
-    createItem('🐞 Bugs Fixed', bugsList)
-  ]
-    .filter(Boolean)
-    .join('\n');
-
-  console.log(rendered);
-}
-
-main();
+* Fixed an issue where users had an option to repeat tasks biweekly
+* Fixed searching project members - [Task-4960057](https://app.productive.io/109-productive/tasks/task/4960057)
+* Removed the client access settings from internal budgets - [Task-4840019](https://app.productive.io/109-productive/tasks/task/4840019)
+* Percentages in financials blocks component now support some edge casese
+* Allow saving subscription form if it's not dirty - [Task-4884578](https://app.productive.io/109-productive/tasks/task/4884578)
+* Fixed sorting by due date and assignee on tasks screen - [Task-4941997](https://app.productive.io/109-productive/tasks/task/4941997)
+* Client roles are removed from budget membership picker - [Task-4877159](https://app.productive.io/109-productive/tasks/task/4877159)
+* Removed the label "Overhead - Turned off/on" if overhead is disabled in settings - [Task-4936699](https://app.productive.io/109-productive/tasks/task/4936699)
+* Fixed the option to hide and show fields on the task modal - [Task-4913101](https://app.productive.io/109-productive/tasks/task/4913101)
+* Default date format selected in settings is now being used inside all tables, lists, boards, calendars and timelines
+`)

--- a/bin/test.js
+++ b/bin/test.js
@@ -22,7 +22,7 @@ console.log(`
 * Allow saving subscription form if it's not dirty - [Task-4884578](https://app.productive.io/109-productive/tasks/task/4884578)
 * Fixed sorting by due date and assignee on tasks screen - [Task-4941997](https://app.productive.io/109-productive/tasks/task/4941997)
 * Client roles are removed from budget membership picker - [Task-4877159](https://app.productive.io/109-productive/tasks/task/4877159)
-* Removed the label "Overhead - Turned off/on" if overhead is disabled in settings - [Task-4936699](https://app.productive.io/109-productive/tasks/task/4936699)
+* Removed the label Overhead - Turned off/on if overhead is disabled in settings - [Task-4936699](https://app.productive.io/109-productive/tasks/task/4936699)
 * Fixed the option to hide and show fields on the task modal - [Task-4913101](https://app.productive.io/109-productive/tasks/task/4913101)
 * Default date format selected in settings is now being used inside all tables, lists, boards, calendars and timelines
 `)

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  branches: ['main', {name: 'develop', prerelease: true}],
+  branches: ['main', { name: 'develop', prerelease: true }],
   repositoryUrl: 'https://github.com/ShockwaVee/react-github-actions',
   plugins: [
     '@semantic-release/commit-analyzer',

--- a/release.config.js
+++ b/release.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-  branches: 'main',
+  branches: ['main', {name: 'develop', prerelease: true}],
   repositoryUrl: 'https://github.com/ShockwaVee/react-github-actions',
   plugins: [
     '@semantic-release/commit-analyzer',


### PR DESCRIPTION

  ## 🧭 New Features

  - Add manager field to person. - <https://app.productive.io/109-productive/tasks/task/5395856|Task-5395856>

  ## ⭐️ Updates

  - "API access" card in settings renamed to "API integrations" - <https://app.productive.io/109-productive/tasks/task/5353703|Task-5353703>
  - The note field for document information in budgets is now wider - <https://app.productive.io/109-productive/tasks/task/5174377|Task-5174377>
  - Docs toolbar functionality adjustments according to functionality needs - <https://app.productive.io/109-productive/tasks/task/5438324|Task-5438324>

  ## 🧪 Beta features

  - Made the overhead addon toggle visible and fixed a bug when declining recalculation after turning overheads on - <https://app.productive.io/109-productive/tasks/task/5534258|Task-5534258>
  - Removed the undertime/overtime information and overhead actions from the table - <https://app.productive.io/109-productive/tasks/task/5534616|Task-5534616>
  - Removed the undertime/overtime logic which can now be controlled more granually - <https://app.productive.io/109-productive/tasks/task/5534779|Task-5534779>
  - Checklists in Docs - <https://app.productive.io/109-productive/tasks/task/5027389|Task-5027389>
  - This reverts commit 4668afd2320042fff3735bdb2064973204c10c0c.
  - Added separate flags for unstable permissions - <https://app.productive.io/109-productive/tasks/task/5086330|Task-5086330>
  - Added support for subscription products (HR integrations) - <https://app.productive.io/109-productive/tasks/task/4054786|Task-4054786>
  - Implemented new permission group called "Automations" which enables users to view, add, edit or delete automations.
  - Fixed an issue where the button for creating a new budget would be visible without the permission - <https://app.productive.io/109-productive/tasks/task/5470741|Task-5470741>
  - Bulk editing time entries and changing the service to non-billable will now show a warning - <https://app.productive.io/109-productive/tasks/task/5451749|Task-5451749>
  - Added a "Show/Hide" button for facility costs form on overhead details modal
  - Reload items on deal -> time entries table when changing service - <https://app.productive.io/109-productive/tasks/task/5451087|Task-5451087>
  - Added template projects policy revamp BF - <https://app.productive.io/109-productive/tasks/task/4997085|Task-4997085>
  - Allowed users to bulk move time entries to other projects - <https://app.productive.io/109-productive/tasks/task/5176655|Task-5176655>

  ## 🐞 Bugs Fixed

  - Update plan if you have HR integrations product without causing errors - <https://app.productive.io/109-productive/tasks/task/4054786|Task-4054786>
  - Quick add should now show allowed objects when user doesn't have permissions for time entries, expenses nor tasks - <https://app.productive.io/109-productive/tasks/task/4630100|Task-4630100>
  - Deleted the failing unit test
  - We've given the 'deal owner' dynamic group a makeover worthy of a design review. 🎩✨ We've not only moved it to the top of the list, but we've also revamped its contents to proudly display the real deal owner instead of a generic dynamic group. No more imposter syndrome for our deal owners! 🦸‍♂️💼 And as a grand finale, we've bid farewell to the 'deal owner' dynamic group option from the select field. Sayonara, old friend! 👋🚀 - <https://app.productive.io/109-productive/tasks/task/5181856|Task-5181856>
  - Always display the second tax in the document template builder when it has 0 as a value - <https://app.productive.io/109-productive/tasks/task/5516142|Task-5516142>
  - Fixed billing plan translation typos (annualy -> annually, biannualy -> biannually) - <https://app.productive.io/109-productive/tasks/task/5533092|Task-5533092>
  - Now, you can conjure up new budgets even when the client company has no projects AND the mystical 'projectless budgets' flag is fluttering in the breeze. 🪙🏰 No need for projects to hold you back; let your budgetary creativity run wild in this projectless wonderland! 🚀💰🪄 - <https://app.productive.io/109-productive/tasks/task/5463662|Task-5463662>
  - Fix for preventing file upload request when uploading avatars that are too large - <https://app.productive.io/109-productive/tasks/task/5522585|Task-5522585>
  - Our financial item report had a bit of time-travel glitch where today's bookings were unexpectedly marked as past events. 📅🚀 Time-space continuum shenanigans, anyone? But worry not, we've patched things up, and now our report will have its dates firmly grounded in the present, no more time-warping surprises. Happy reporting, fellow temporal adventurers! 🕰️💼 - <https://app.productive.io/109-productive/tasks/task/5474963|Task-5474963>
  - Resolved issue preventing Timesheet PDF from opening in an invoice - <https://app.productive.io/109-productive/tasks/task/5501065|Task-5501065>
  - Our active filter occasionally got distracted by the scent of roses and went on a little adventure, leaving us with the infamous 'undefined is not an object' error. 🌹🧐 This fix brings our wayward active filter back on track, putting an end to the 'undefined is not an object' error and ensuring a smooth journey for all. No more detours, just code that works flawlessly! 🚀🛠️ - <https://app.productive.io/109-productive/tasks/task/5350032|Task-5350032>
  - Add to project button will not be show users who has not permission for action - <https://app.productive.io/109-productive/tasks/task/5474759|Task-5474759>
  - Fixed doc or page title in the modal window when deleting a document - <https://app.productive.io/109-productive/tasks/task/5511810|Task-5511810>